### PR TITLE
bugfix for moab scheduler job dependency format

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Description: This framework allows you to design and implement complex
     been built keeping in mind the needs of bioinformatics workflows. However, it is
     easily extendable to any field where a series of steps (shell commands) are to
     be executed in a (work)flow.
-Version: 0.9.10.9016
+Version: 0.9.10.9017
 Depends:
     R (>= 3.0.2),
     methods,

--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,15 @@ source: "github.com/sahilseth/flowr/tree/devel/NEWS.md"
 
 <br>
 
+flowr 0.9.10.9017
+----------------------------------------------
+> 2016-10-01
+
+* bugfix in `render-dependency.R` script
+    * corrected `moab` dependency function, *render_dependency.moab* to correctly format dependency arguments in MSUB script, e.g., `#MSUB -l depend=afterok:960775:960854` instead of `#MSUB -l  depend=afterok:960775: depend=afterok:960854`
+    * https://github.com/sahilseth/flowr/blob/master/R/render-dependency.R#L60
+* bugfix for `render_dependency.sge` function same as for `moab`: Untested
+
 flowr 0.9.10 (dates)
 ----------------------------------------------
 > 2016-04-18

--- a/R/render-dependency.R
+++ b/R/render-dependency.R
@@ -63,13 +63,11 @@ render_dependency.moab <- function(x, index, ...){
 		dep = sprintf("-l depend=afterok:%s",
 									paste(unlist(x@dependency), collapse = ":"))
 	}else if(dep_type == "serial"){
-		dep <- sprintf("-l %s", paste(" depend=afterok:",
-																	x@dependency[[index]],
+		dep <- sprintf("-l depend=afterok:%s", paste(x@dependency[[index]],
 																	sep="", collapse=":"))
 	}else if(dep_type == "burst"){
 		index=1
-		dep <- sprintf("-l %s",paste(" depend=afterok:",
-																 x@dependency[[index]], sep="",
+		dep <- sprintf("-l depend=afterok:%s",paste(x@dependency[[index]], sep="",
 																 collapse=":"))
 	}else{dep = ""}
 	return(dep)
@@ -81,13 +79,11 @@ render_dependency.sge <- function(x, index, ...){
 		dep = sprintf("-W depend=afterok:%s",
 									paste(unlist(x@dependency), collapse = ":"))
 	}else if(dep_type == "serial"){
-		dep <- sprintf("-W %s", paste(" depend=afterok:",
-																	x@dependency[[index]],
+		dep <- sprintf("-W depend=afterok:%s", paste(x@dependency[[index]],
 																	sep="", collapse=":"))
 	}else if(dep_type == "burst"){
 		index=1
-		dep <- sprintf("-W %s",paste(" depend=afterok:",
-																 x@dependency[[index]], sep="",
+		dep <- sprintf("-W depend=afterok:%s",paste(x@dependency[[index]], sep="",
 																 collapse=":"))
 	}else{dep = ""}
 	return(dep)
@@ -110,7 +106,3 @@ render_dependency.slurm <- function(x, index, ...){
 	}else{dep = ""}
 	return(dep)
 }
-
-
-
-


### PR DESCRIPTION
* bugfix in `render-dependency.R` script
    * corrected `moab` dependency function, *render_dependency.moab* to correctly format dependency arguments in MSUB script, e.g., `#MSUB -l depend=afterok:960775:960854` instead of `#MSUB -l  depend=afterok:960775: depend=afterok:960854`. Tested OK on HPC running moab scheduler
    * similar fix for sge scheduler too but untested.on HPC running sge scheduler