### PR TITLE
Fix for #73 and #74.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Description: This framework allows you to design and implement complex
     been built keeping in mind the needs of bioinformatics workflows. However, it is
     easily extendable to any field where a series of steps (shell commands) are to
     be executed in a (work)flow.
-Version: 0.9.10.9020
+Version: 0.9.10.9021
 Depends:
     R (>= 3.0.2),
     methods,

--- a/R/render-dependency.R
+++ b/R/render-dependency.R
@@ -18,7 +18,8 @@ render_dependency.local <- function(...){
   return("")
 }
 
-## http://docs.adaptivecomputing.com/torque/4-1-4/Content/topics/commands/qsub.htm
+# http://docs.adaptivecomputing.com/torque/4-1-4/Content/topics/commands/qsub.htm
+
 render_dependency.torque <- function(x, index, ...){
   dep_type = x@dependency_type
   
@@ -26,14 +27,14 @@ render_dependency.torque <- function(x, index, ...){
     dep = sprintf("-W depend=afterok:%s",
                   paste(unlist(x@dependency), collapse = ":"))
   }else if(dep_type == "serial"){
-    dep <- sprintf("-W %s", paste(" depend=afterok:",
-                                  x@dependency[[index]],
-                                  sep="", collapse=":"))
+    dep <- sprintf("-W depend=afterok:%s", 
+                   paste(x@dependency[[index]],sep="", collapse=":"))
+  
   }else if(dep_type == "burst"){
     index=1
-    dep <- sprintf("-W %s",paste(" depend=afterok:",
-                                 x@dependency[[index]], sep="",
-                                 collapse=":"))
+    dep <- sprintf("-W  depend=afterok:%s", 
+                   paste(x@dependency[[index]], sep="", collapse=":"))
+    
   }else{dep = ""}
   return(dep)
 }
@@ -47,7 +48,7 @@ render_dependency.lsf <- function(x, index, ...){
     dep <- sprintf("-w '%s' -ti",
                    paste(unlist(x@dependency), collapse = " && "))
   }else if(dep_type == "serial"){
-     dep <- sprintf("-w '%s' -ti", paste(x@dependency[[index]], collapse=" && "))
+    dep <- sprintf("-w '%s' -ti", paste(x@dependency[[index]], collapse=" && "))
   }else if(dep_type == "burst"){
     index=1
     dep <- sprintf("-w '%s' -ti", paste(x@dependency[[index]],
@@ -62,38 +63,43 @@ render_dependency.test = render_dependency.lsf
 # @samin, change dependency format for moab
 
 render_dependency.moab <- function(x, index, ...){
-
-	dep_type = x@dependency_type
-	if(dep_type == 'gather'){
-		dep = sprintf("-l depend=afterok:%s",
-									paste(unlist(x@dependency), collapse = ":"))
-	}else if(dep_type == "serial"){
-		dep <- sprintf("-l %s", paste(" depend=afterok:",
-																	x@dependency[[index]],
-																	sep="", collapse=":"))
-	}else if(dep_type == "burst"){
-		index=1
-		dep <- sprintf("-l %s",paste(" depend=afterok:",
-																 x@dependency[[index]], sep="",
-																 collapse=":"))
-	}else{dep = ""}
-	return(dep)
+  
+  dep_type = x@dependency_type
+  if(dep_type == 'gather'){
+    dep = sprintf("-l depend=afterok:%s",
+                  paste(unlist(x@dependency), collapse = ":"))
+  }else if(dep_type == "serial"){
+    dep <- sprintf("-l depend=afterok:%s", paste(x@dependency[[index]],
+                                                 sep="", collapse=":"))
+  }else if(dep_type == "burst"){
+    index=1
+    dep <- sprintf("-l depend=afterok: %s",paste(x@dependency[[index]], sep="",
+                                                 collapse=":"))
+  }else{dep = ""}
+  return(dep)
 }
 
 render_dependency.sge <- function(x, index, ...){
   dep_type = x@dependency_type
+  
+  # wait for all previous jobs
+  # MSUB -l depend=afterok:960775:960854
   if(dep_type == 'gather'){
     dep = sprintf("-W depend=afterok:%s",
                   paste(unlist(x@dependency), collapse = ":"))
+  
+  # one for each previous job
+  # MSUB -l depend=afterok:960775
+  # MSUB -l depend=afterok:960854
   }else if(dep_type == "serial"){
-    dep <- sprintf("-W %s", paste(" depend=afterok:",
-                                  x@dependency[[index]],
-                                  sep="", collapse=":"))
+    dep <- sprintf("-W depend=afterok:%s", 
+                   paste(x@dependency[[index]], sep="", collapse=":"))
+  
+  # MSUB -l depend=afterok:960775
   }else if(dep_type == "burst"){
     index=1
-    dep <- sprintf("-W %s",paste(" depend=afterok:",
-                                 x@dependency[[index]], sep="",
-                                 collapse=":"))
+    dep <- sprintf("-W depend=afterok:%s",
+                   paste(x@dependency[[index]], sep="", collapse=":"))
   }else{dep = ""}
   return(dep)
 }
@@ -101,19 +107,19 @@ render_dependency.sge <- function(x, index, ...){
 
 ## this has not been tested !
 render_dependency.slurm <- function(x, index, ...){
-	dep_type = x@dependency_type
-	if(dep_type == 'gather'){
-		dep = sprintf("--dependency=afterok:%s",
-									paste(unlist(x@dependency), collapse = ":"))
-	}else if(dep_type == "serial"){ ## collapse jobs at a specific index
-		dep <- sprintf("--dependency=afterok:%s", 
-									 paste(x@dependency[[index]], sep="", collapse=":"))
-	}else if(dep_type == "burst"){
-		index=1 ## ALL of them would see index 1
-		dep <- sprintf("--dependency=afterok:%s",
-									 paste(x@dependency[[index]], sep="", collapse=":"))
-	}else{dep = ""}
-	return(dep)
+  dep_type = x@dependency_type
+  if(dep_type == 'gather'){
+    dep = sprintf("--dependency=afterok:%s",
+                  paste(unlist(x@dependency), collapse = ":"))
+  }else if(dep_type == "serial"){ ## collapse jobs at a specific index
+    dep <- sprintf("--dependency=afterok:%s", 
+                   paste(x@dependency[[index]], sep="", collapse=":"))
+  }else if(dep_type == "burst"){
+    index=1 ## ALL of them would see index 1
+    dep <- sprintf("--dependency=afterok:%s",
+                   paste(x@dependency[[index]], sep="", collapse=":"))
+  }else{dep = ""}
+  return(dep)
 }
 
 


### PR DESCRIPTION
#MSUB -l depend=afterok:960775:960854 works for scatter-gather but not the current format, #MSUB -l depend=afterok:960775: depend=afterok:960854