### PR TITLE
Updated SBATCH params

### DIFF
--- a/inst/conf/slurm.sh
+++ b/inst/conf/slurm.sh
@@ -1,15 +1,19 @@
 #!/bin/bash
-#SBATCH -J {{{JOBNAME}}}
-#SBATCH -N {{{NODES}}}
-#SBATCH -n {{{CPU}}}
-#SBATCH -D {{{CWD}}}
-#SBATCH --error={{{STDOUT}}}
-#SBATCH --output={{{STDOUT}}}
-#SBATCH --partition={{{QUEUE}}}
-#SBATCH --time={{{WALLTIME}}} 
-#SBATCH --mem={{{MEMORY}}}
-#SBATCH {{{DEPENDENCY}}}
-#SBATCH {{{EXTRA_OPTS}}}
+#SBATCH --job-name={{{JOBNAME}}}                        # name of the job
+#SBATCH --chdir={{{CWD}}}                               # the workding dir for each job
+#SBATCH --output={{{STDOUT}}}                           # output is sent to logfile, stdout + stderr by default
+#SBATCH --error={{{STDOUT}}}                            # output is sent to logfile, stdout + stderr by default
+#SBATCH --partition={{{PARTITION}}}                     # Job partition
+#SBATCH --qos={{{QUEUE}}}                               # Job queue or qos, defined by column:queue in flowr.def
+#SBATCH --time={{{WALLTIME}}}                      	    # Walltime, defined by column:walltime in flowr.def
+#SBATCH --mem={{{MEMORY}}}                              # Memory, defined by column:memory_reserved in flowr.def
+#SBATCH --nodes={{{NODES}}}                 		        # Nodes, defined by column:nodes in flowr.def
+#SBATCH --ntasks={{{CPU}}}                 			        # CPU reserved, defined by column:cpu_reserved in flowr.def
+#SBATCH --mail-type=FAIL                                # send email when job fails
+#SBATCH --requeue --export=all                          # enable requeue and export current shell env
+#SBATCH {{{DEPENDENCY}}}                                # slurm dependency, https://slurm.schedmd.com/sbatch.html
+#SBATCH {{{EXTRA_OPTS}}}                                # extra options
+
 
 
 ## ------------------------------ n o t e s -------------------------##


### PR DESCRIPTION
Previous params worked for most times except when queue from flowr.def via {{{QUEUE}}} variable should point to slurm equivalent `--qos`.